### PR TITLE
style: move declarations above nested rules

### DIFF
--- a/dist/components/EInput/EInput.scss
+++ b/dist/components/EInput/EInput.scss
@@ -32,10 +32,9 @@ $component: c('EInput');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;
@@ -64,7 +63,8 @@ $component: c('EInput');
     outline: none;
     appearance: none;
 
-    transition: border-color v(transition-time) v(transition-type),
+    transition:
+      border-color v(transition-time) v(transition-type),
       box-shadow v(transition-time) v(transition-type);
 
     &::placeholder {

--- a/dist/components/ESelect/ESelect.scss
+++ b/dist/components/ESelect/ESelect.scss
@@ -37,10 +37,9 @@ $component: c('ESelect');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;

--- a/dist/components/ETextarea/ETextarea.scss
+++ b/dist/components/ETextarea/ETextarea.scss
@@ -32,10 +32,9 @@ $component: c('ETextarea');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;

--- a/src/components/EInput/EInput.scss
+++ b/src/components/EInput/EInput.scss
@@ -32,10 +32,9 @@ $component: c('EInput');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;
@@ -64,7 +63,8 @@ $component: c('EInput');
     outline: none;
     appearance: none;
 
-    transition: border-color v(transition-time) v(transition-type),
+    transition:
+      border-color v(transition-time) v(transition-type),
       box-shadow v(transition-time) v(transition-type);
 
     &::placeholder {

--- a/src/components/ESelect/ESelect.scss
+++ b/src/components/ESelect/ESelect.scss
@@ -37,10 +37,9 @@ $component: c('ESelect');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;

--- a/src/components/ETextarea/ETextarea.scss
+++ b/src/components/ETextarea/ETextarea.scss
@@ -32,10 +32,9 @@ $component: c('ETextarea');
 .#{$component} {
   display: inline-flex;
   flex-direction: column;
+  line-height: v(line-height, $component);
 
   @include variants;
-
-  line-height: v(line-height, $component);
 
   &.#{$component}--block {
     display: flex;


### PR DESCRIPTION
Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version.

See https://sass-lang.com/documentation/breaking-changes/mixed-decls/